### PR TITLE
Cleanup operation definitions

### DIFF
--- a/input/fsh/metadata.fsh
+++ b/input/fsh/metadata.fsh
@@ -26,3 +26,6 @@ RuleSet: PageableOperationProfile
 
 RuleSet: ArtifactVersionBindableOperationProfile
 * meta.profile[+] = Canonical(ArtifactVersionBindableOperation)
+
+RuleSet: ArtifactEndpointConfigurableOperationProfile
+* meta.profile[+] = Canonical(ArtifactEndpointConfigurableOperation)

--- a/input/fsh/operation-definitions/data-requirements-operation.fsh
+++ b/input/fsh/operation-definitions/data-requirements-operation.fsh
@@ -93,8 +93,7 @@ The version of the canonical resource to analyze
 * parameter[=].documentation = """
 A business identifier of the canonical resource to be analyzed.
 """
-* parameter[=].type = #string
-* parameter[=].searchType = #token
+* parameter[=].type = #Identifier
 
 * parameter[+].name = #expression
 * parameter[=].use = #in
@@ -186,7 +185,22 @@ in the manifest library have the same meaning as specifying that code system or 
 canonical version in the `system-version` parameter of an expand or the `canonicalVersion` 
 parameter.
 """
-* parameter[=].type = #uri
+* parameter[=].type = #Library
+
+* parameter[+].name = #manifestReference
+* parameter[=].use = #in
+* parameter[=].min = 0
+* parameter[=].max = "1"
+* parameter[=].documentation = """
+Specifies a reference to an asset-collection library that defines version bindings for code
+systems and other canonical resources referenced by the value set(s) being expanded
+and other canonical resources referenced by the artifact. When specified, code
+systems and other canonical resources identified as `depends-on` related artifacts 
+in the manifest library have the same meaning as specifying that code system or other
+canonical version in the `system-version` parameter of an expand or the `canonicalVersion` 
+parameter.
+"""
+* parameter[=].type = #canonical
 
 * parameter[+]
   * name = #include

--- a/input/fsh/operation-definitions/data-requirements-operation.fsh
+++ b/input/fsh/operation-definitions/data-requirements-operation.fsh
@@ -4,7 +4,8 @@ Title: "CRMI Data Requirements Operation"
 Usage: #definition
 * insert DefinitionMetadata
 * insert ArtifactOperationProfile
-* insert ArtifactVersionBindableOperationProfile 
+* insert ArtifactVersionBindableOperationProfile
+* insert ArtifactEndpointConfigurableOperationProfile
 * insert ManifestableOperationProfile
 * name = "CRMIDataRequirements"
 * title = "CRMI Data Requirements"
@@ -215,16 +216,59 @@ values are:
 """
 
 * parameter[+]
-  * name = #contentEndpoint
-  * min = 0
-  * max = "1"
-  * use = #in
-  * type = #Endpoint
+  * name = #artifactEndpointConfiguration
   * documentation = """
-An endpoint to use to access content (i.e. libraries, activities, measures, questionnaires, and plans) referenced by the
-artifact. If no content endpoint is supplied the evaluation will attempt to
-retrieve content from the server on which the operation is being performed.
+Configuration information to resolve canonical artifacts
+* `artifactRoute`: An optional route used to determine whether this endpoint is expected to be able to resolve artifacts that match the route (i.e. start with the route, up to and including the entire url)
+* `endpointUri`: The URI of the endpoint, exclusive with the `endpoint` parameter
+* `endpoint`: An Endpoint resource describing the endpoint, exclusive with the `endpointUri` parameter
+
+**Processing semantics**:
+
+Create a canonical-like reference (e.g.
+`{canonical.url}|{canonical.version}` or similar extensions for non-canonical artifacts).
+
+* Given a single `artifactEndpointConfiguration`
+  * When `artifactRoute` is present
+    * And `artifactRoute` *starts with* canonical or artifact reference
+    * Then attempt to resolve with `endpointUri` or `endpoint`
+  * When `artifactRoute` is not present
+    * Then attempt to resolve with `endpointUri` or `endpoint`
+* Given multiple `artifactEndpointConfiguration`s
+  * Then rank order each configuration (see below)
+  * And attempt to resolve with `endpointUri` or `endpoint` in order until resolved
+
+Rank each `artifactEndpointConfiguration` such that:
+* if `artifactRoute` is present *and* `artifactRoute` *starts with* canonical or artifact reference: rank based on number of matching characters 
+* if `artifactRoute` is *not* present: include but rank lower
+
+NOTE: For evenly ranked `artifactEndpointConfiguration`s, order as defined in the
+OperationDefinition.
 """
+  * min = 0
+  * max = "*"
+  * use = #in
+  
+  * part[+]
+    * name = #artifactRoute
+    * min = 0
+    * max = "1"
+    * type = #uri
+    * use = #in
+  
+  * part[+]
+    * name = #endpointUri
+    * min = 0
+    * max = "1"
+    * type = #uri
+    * use = #in
+
+  * part[+]
+    * name = #endpoint
+    * min = 0
+    * max = "1"
+    * type = #Endpoint
+    * use = #in
 
 * parameter[+]
   * name = #terminologyEndpoint

--- a/input/fsh/operation-definitions/data-requirements-operation.fsh
+++ b/input/fsh/operation-definitions/data-requirements-operation.fsh
@@ -41,6 +41,8 @@ systems, value sets, and direct-reference codes), parameters, dependencies
 * resource[+] = #ImplementationGuide
 * resource[+] = #Library
 * resource[+] = #Measure
+* resource[+] = #Medication
+* resource[+] = #MedicationKnowledge
 * resource[+] = #MessageDefinition
 * resource[+] = #NamingSystem
 * resource[+] = #OperationDefinition
@@ -52,6 +54,7 @@ systems, value sets, and direct-reference codes), parameters, dependencies
 * resource[+] = #SearchParameter
 * resource[+] = #StructureDefinition
 * resource[+] = #StructureMap
+* resource[+] = #Substance
 * resource[+] = #TerminologyCapabilities
 * resource[+] = #TestScript
 * resource[+] = #ValueSet
@@ -64,7 +67,7 @@ systems, value sets, and direct-reference codes), parameters, dependencies
 * parameter[=].min = 0
 * parameter[=].max = "1"
 * parameter[=].documentation = """
-The logical id of the canonical resource to analyze.
+The logical id of the canonical or artifact resource to analyze.
 """
 * parameter[=].type = #string
 
@@ -73,7 +76,7 @@ The logical id of the canonical resource to analyze.
 * parameter[=].min = 0
 * parameter[=].max = "1"
 * parameter[=].documentation = """
-A canonical reference to a canonical resource.
+A canonical or artifact reference to a canonical resource.
 """
 * parameter[=].type = #uri
 
@@ -82,7 +85,7 @@ A canonical reference to a canonical resource.
 * parameter[=].min = 0
 * parameter[=].max = "1"
 * parameter[=].documentation = """
-The version of the canonical resource to analyze
+The version of the canonical or artifact resource to analyze
 """
 * parameter[=].type = #string
 
@@ -91,9 +94,10 @@ The version of the canonical resource to analyze
 * parameter[=].min = 0
 * parameter[=].max = "1"
 * parameter[=].documentation = """
-A business identifier of the canonical resource to be analyzed.
+A business identifier of the canonical or artifact resource to be analyzed.
 """
-* parameter[=].type = #Identifier
+* parameter[=].type = #string
+* parameter[=].searchType = #token
 
 * parameter[+].name = #expression
 * parameter[=].use = #in
@@ -128,7 +132,7 @@ NOTE: Does this only apply to Library resource types?
 * parameter[=].min = 0
 * parameter[=].max = "*"
 * parameter[=].documentation = """
-Specifies a version to use for a canonical resource if the artifact referencing 
+Specifies a version to use for a canonical or artifact resource if the artifact referencing 
 the resource does not already specify a version. The format is the same as a canonical URL:
 [url]|[version] - e.g. http://loinc.org|2.56 
 
@@ -142,7 +146,7 @@ to apply to any canonical resource, including code systems.
 * parameter[=].min = 0
 * parameter[=].max = "*"
 * parameter[=].documentation = """
-Edge Case: Specifies a version to use for a canonical resource. If the artifact referencing 
+Edge Case: Specifies a version to use for a canonical or artifact resource. If the artifact referencing 
 the resource specifies a different version, an error is returned instead of the package. The
 format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 
 
@@ -156,7 +160,7 @@ apply to any canonical resource, including code systems.
 * parameter[=].min = 0
 * parameter[=].max = "*"
 * parameter[=].documentation = """
-Edge Case: Specifies a version to use for a canonical resource. This parameter overrides any
+Edge Case: Specifies a version to use for a canonical or artifact resource. This parameter overrides any
 specified version in the artifact (and any artifacts it depends on). The
 format is the same as a canonical URL: [system]|[version] - e.g.
 http://loinc.org|2.56. Note that this has obvious safety issues, in that it may
@@ -185,22 +189,8 @@ in the manifest library have the same meaning as specifying that code system or 
 canonical version in the `system-version` parameter of an expand or the `canonicalVersion` 
 parameter.
 """
-* parameter[=].type = #Library
-
-* parameter[+].name = #manifestReference
-* parameter[=].use = #in
-* parameter[=].min = 0
-* parameter[=].max = "1"
-* parameter[=].documentation = """
-Specifies a reference to an asset-collection library that defines version bindings for code
-systems and other canonical resources referenced by the value set(s) being expanded
-and other canonical resources referenced by the artifact. When specified, code
-systems and other canonical resources identified as `depends-on` related artifacts 
-in the manifest library have the same meaning as specifying that code system or other
-canonical version in the `system-version` parameter of an expand or the `canonicalVersion` 
-parameter.
-"""
 * parameter[=].type = #canonical
+* parameter[=].targetProfile = Canonical(http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-manifestlibrary)
 
 * parameter[+]
   * name = #include

--- a/input/fsh/operation-definitions/package-operation.fsh
+++ b/input/fsh/operation-definitions/package-operation.fsh
@@ -24,6 +24,7 @@ TODO: More documentation about the operation, including inline examples:
 """
 * kind = #operation
 * code = #crmi.package
+
 * resource[+] = #ActivityDefinition
 * resource[+] = #CapabilityStatement
 * resource[+] = #ChargeItemDefinition
@@ -39,6 +40,8 @@ TODO: More documentation about the operation, including inline examples:
 * resource[+] = #ImplementationGuide
 * resource[+] = #Library
 * resource[+] = #Measure
+* resource[+] = #Medication
+* resource[+] = #MedicationKnowledge
 * resource[+] = #MessageDefinition
 * resource[+] = #NamingSystem
 * resource[+] = #OperationDefinition
@@ -50,6 +53,7 @@ TODO: More documentation about the operation, including inline examples:
 * resource[+] = #SearchParameter
 * resource[+] = #StructureDefinition
 * resource[+] = #StructureMap
+* resource[+] = #Substance
 * resource[+] = #TerminologyCapabilities
 * resource[+] = #TestScript
 * resource[+] = #ValueSet
@@ -71,7 +75,7 @@ TODO: More documentation about the operation, including inline examples:
   * max = "1"
   * use = #in
   * type = #uri
-  * documentation = "A canonical reference to a Resource to package on the server."
+  * documentation = "A canonical or artifact reference to a Resource to package on the server."
 
 * parameter[+]
   * name = #version
@@ -86,7 +90,8 @@ TODO: More documentation about the operation, including inline examples:
   * min = 0
   * max = "1"
   * use = #in
-  * type = #Identifier
+  * type = #string
+  * searchType = #token
   * documentation = "A business identifier of the Resource."
 
 * parameter[+]
@@ -109,7 +114,7 @@ packaged content.
   * use = #in
   * type = #uri
   * documentation = """
-Specifies a version to use for a canonical resource if the artifact referencing 
+Specifies a version to use for a canonical or artifact resource if the artifact referencing 
 the resource does not already specify a version. The format is the same as a canonical URL:
 [url]|[version] - e.g. http://loinc.org|2.56 Note that this is a generalization of the `system-version`
 parameter to the $expand operation to apply to any canonical resource, including code systems.
@@ -122,7 +127,7 @@ parameter to the $expand operation to apply to any canonical resource, including
   * use = #in
   * type = #uri
   * documentation = """
-Edge Case: Specifies a version to use for a canonical resource. If the artifact referencing 
+Edge Case: Specifies a version to use for a canonical or artifact resource. If the artifact referencing 
 the resource specifies a different version, an error is returned instead of the package. The
 format is the same as a canonical URL: [url]|[version] - e.g. http://loinc.org|2.56 Note that
 this is a generalization of the `check-system-version` parameter to the $expand operation to 
@@ -136,7 +141,7 @@ apply to any canonical resource, including code systems.
   * use = #in
   * type = #uri
   * documentation = """
-Edge Case: Specifies a version to use for a canonical resource. This parameter overrides any
+Edge Case: Specifies a version to use for a canonical or artifact resource. This parameter overrides any
 specified version in the artifact (and any artifacts it depends on). The
 format is the same as a canonical URL: [system]|[version] - e.g.
 http://loinc.org|2.56. Note that this has obvious safety issues, in that it may
@@ -154,23 +159,8 @@ including code systems.
   * min = 0
   * max = "1"
   * use = #in
-  * type = #Library
-  * documentation = """
-Specifies an asset-collection library that defines version bindings for code
-systems and other canonical resources referenced by the value set(s) being expanded
-and other canonical resources referenced by the artifact. When specified, code
-systems and other canonical resources identified as `depends-on` related artifacts 
-in the manifest library have the same meaning as specifying that code system or other
-canonical version in the `system-version` parameter of an expand or the `canonicalVersion` 
-parameter.
-"""
-
-* parameter[+]
-  * name = #manifestReference
-  * min = 0
-  * max = "1"
-  * use = #in
   * type = #canonical
+  * targetProfile = Canonical(http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-manifestlibrary)
   * documentation = """
 Specifies a reference to an asset-collection library that defines version
 bindings for code systems and other canonical resources referenced by the value

--- a/input/fsh/operation-definitions/package-operation.fsh
+++ b/input/fsh/operation-definitions/package-operation.fsh
@@ -4,7 +4,8 @@ Title: "CRMI Package Operation"
 Usage: #definition
 * insert DefinitionMetadata
 * insert ArtifactOperationProfile
-* insert ArtifactVersionBindableOperationProfile 
+* insert ArtifactVersionBindableOperationProfile
+* insert ArtifactEndpointConfigurableOperationProfile 
 * insert ManifestableOperationProfile
 * name = "CRMIPackage"
 * title = "CRMI Package"
@@ -228,16 +229,59 @@ include resources regardless of what implementation guide or specification they 
 """
 
 * parameter[+]
-  * name = #contentEndpoint
-  * min = 0
-  * max = "1"
-  * use = #in
-  * type = #Endpoint
+  * name = #artifactEndpointConfiguration
   * documentation = """
-An endpoint to use to access content (i.e. libraries, activities, measures, questionnaires, and plans) referenced by the
-artifact. If no content endpoint is supplied the evaluation will attempt to
-retrieve content from the server on which the operation is being performed. 
+Configuration information to resolve canonical artifacts
+* `artifactRoute`: An optional route used to determine whether this endpoint is expected to be able to resolve artifacts that match the route (i.e. start with the route, up to and including the entire url)
+* `endpointUri`: The URI of the endpoint, exclusive with the `endpoint` parameter
+* `endpoint`: An Endpoint resource describing the endpoint, exclusive with the `endpointUri` parameter
+
+**Processing semantics**:
+
+Create a canonical-like reference (e.g.
+`{canonical.url}|{canonical.version}` or similar extensions for non-canonical artifacts).
+
+* Given a single `artifactEndpointConfiguration`
+  * When `artifactRoute` is present
+    * And `artifactRoute` *starts with* canonical or artifact reference
+    * Then attempt to resolve with `endpointUri` or `endpoint`
+  * When `artifactRoute` is not present
+    * Then attempt to resolve with `endpointUri` or `endpoint`
+* Given multiple `artifactEndpointConfiguration`s
+  * Then rank order each configuration (see below)
+  * And attempt to resolve with `endpointUri` or `endpoint` in order until resolved
+
+Rank each `artifactEndpointConfiguration` such that:
+* if `artifactRoute` is present *and* `artifactRoute` *starts with* canonical or artifact reference: rank based on number of matching characters 
+* if `artifactRoute` is *not* present: include but rank lower
+
+NOTE: For evenly ranked `artifactEndpointConfiguration`s, order as defined in the
+OperationDefinition.
 """
+  * min = 0
+  * max = "*"
+  * use = #in
+  
+  * part[+]
+    * name = #artifactRoute
+    * min = 0
+    * max = "1"
+    * type = #uri
+    * use = #in
+
+  * part[+]
+    * name = #endpointUri
+    * min = 0
+    * max = "1"
+    * type = #uri
+    * use = #in
+
+  * part[+]
+    * name = #endpoint
+    * min = 0
+    * max = "1"
+    * type = #Endpoint
+    * use = #in
 
 * parameter[+]
   * name = #terminologyEndpoint

--- a/input/fsh/operation-definitions/package-operation.fsh
+++ b/input/fsh/operation-definitions/package-operation.fsh
@@ -86,8 +86,7 @@ TODO: More documentation about the operation, including inline examples:
   * min = 0
   * max = "1"
   * use = #in
-  * type = #string
-  * searchType = #token 
+  * type = #Identifier
   * documentation = "A business identifier of the Resource."
 
 * parameter[+]
@@ -155,7 +154,7 @@ including code systems.
   * min = 0
   * max = "1"
   * use = #in
-  * type = #uri
+  * type = #Library
   * documentation = """
 Specifies an asset-collection library that defines version bindings for code
 systems and other canonical resources referenced by the value set(s) being expanded
@@ -164,6 +163,22 @@ systems and other canonical resources identified as `depends-on` related artifac
 in the manifest library have the same meaning as specifying that code system or other
 canonical version in the `system-version` parameter of an expand or the `canonicalVersion` 
 parameter.
+"""
+
+* parameter[+]
+  * name = #manifestReference
+  * min = 0
+  * max = "1"
+  * use = #in
+  * type = #canonical
+  * documentation = """
+Specifies a reference to an asset-collection library that defines version
+bindings for code systems and other canonical resources referenced by the value
+set(s) being expanded and other canonical resources referenced by the artifact.
+When specified, code systems and other canonical resources identified as
+`depends-on` related artifacts in the manifest library have the same meaning as
+specifying that code system or other canonical version in the `system-version`
+parameter of an expand or the `canonicalVersion` parameter.
 """
 
 * parameter[+]

--- a/input/fsh/operation-profiles/artifact-endpoint-configurable-profile.fsh
+++ b/input/fsh/operation-profiles/artifact-endpoint-configurable-profile.fsh
@@ -31,7 +31,6 @@ Rank each `artifactEndpointConfiguration` such that:
 
 NOTE: For evenly ranked `artifactEndpointConfiguration`s, order as defined in the
 OperationDefinition.
-
 """
 
 * parameter

--- a/input/fsh/operation-profiles/artifact-endpoint-configurable-profile.fsh
+++ b/input/fsh/operation-profiles/artifact-endpoint-configurable-profile.fsh
@@ -6,28 +6,28 @@ Description: """
 Profile for operations where artifact endpoint configuration can be specified.
 
 * `artifactEndpointConfiguration`: Configuration information to resolve canonical artifacts
-  * `canonicalRoute`: An optional route used to determine whether this endpoint is expected to be able to resolve artifacts that match the route (i.e. start with the route, up to and including the entire url)
+  * `artifactRoute`: An optional route used to determine whether this endpoint is expected to be able to resolve artifacts that match the route (i.e. start with the route, up to and including the entire url)
   * `endpointUri`: The URI of the endpoint, exclusive with the `endpoint` parameter
   * `endpoint`: An Endpoint resource describing the endpoint, exclusive with the `endpointUri` parameter
 
 **Processing semantics**:
 
-Create a canonical reference from the canonical resource (e.g.
-`{canonical.url}|{canonical.version}`).
+Create a canonical-like reference (e.g.
+`{canonical.url}|{canonical.version}` or similar extensions for non-canonical artifacts).
 
 * Given a single `artifactEndpointConfiguration`
-  * When `canonicalRoute` is present
-    * And `canonicalRoute` *starts with* canonical reference
+  * When `artifactRoute` is present
+    * And `artifactRoute` *starts with* canonical or artifact reference
     * Then attempt to resolve with `endpointUri` or `endpoint`
-  * When `canonicalRoute` is not present
+  * When `artifactRoute` is not present
     * Then attempt to resolve with `endpointUri` or `endpoint`
 * Given multiple `artifactEndpointConfiguration`s
   * Then rank order each configuration (see below)
   * And attempt to resolve with `endpointUri` or `endpoint` in order until resolved
 
 Rank each `artifactEndpointConfiguration` such that:
-* if `canonicalRoute` is present *and* `canonicalRoute` *starts with* canonical reference: rank based on number of matching characters 
-* if `canonicalRoute` is *not* present: include but rank lower
+* if `artifactRoute` is present *and* `artifactRoute` *starts with* canonical or artifact reference: rank based on number of matching characters 
+* if `artifactRoute` is *not* present: include but rank lower
 
 NOTE: For evenly ranked `artifactEndpointConfiguration`s, order as defined in the
 OperationDefinition.
@@ -45,9 +45,9 @@ OperationDefinition.
   * part
     * insert SliceOnName
   
-  * part contains canonicalRoute 0..1 MS
-  * part[canonicalRoute]
-    * name = #canonicalRoute
+  * part contains artifactRoute 0..1 MS
+  * part[artifactRoute]
+    * name = #artifactRoute
     * min = 0
     * max = "1"
     * type = #uri

--- a/input/fsh/operation-profiles/artifact-operation-profile.fsh
+++ b/input/fsh/operation-profiles/artifact-operation-profile.fsh
@@ -54,7 +54,8 @@ NOTE: When involking canonical operations using any combination of `url`,
   * use = #in
   * min = 0
   * max = "1"
-  * type = #Identifier
+  * type = #string
+  * searchType = #token
 
 * parameter contains resource 0..1 MS
 * parameter[resource]

--- a/input/fsh/operation-profiles/artifact-operation-profile.fsh
+++ b/input/fsh/operation-profiles/artifact-operation-profile.fsh
@@ -1,3 +1,8 @@
+Invariant:   crmi-artifact-operation-1
+Description: "Parameter url type is uri or canonical"
+Expression:  "type='uri' or type='canonical'"
+Severity:    #error
+
 Profile: ArtifactOperation
 Id: crmi-artifact-operation
 Parent: OperationDefinition
@@ -33,7 +38,7 @@ NOTE: When involking canonical operations using any combination of `url`,
   * use = #in
   * min = 0
   * max = "1"
-  * type = #uri
+  * obeys crmi-artifact-operation-1
 
 * parameter contains version 0..1 MS
 * parameter[version]
@@ -49,8 +54,7 @@ NOTE: When involking canonical operations using any combination of `url`,
   * use = #in
   * min = 0
   * max = "1"
-  * type = #string
-  * searchType = #token
+  * type = #Identifier
 
 * parameter contains resource 0..1 MS
 * parameter[resource]

--- a/input/fsh/operation-profiles/canonical-version-bindable-operation-profile.fsh
+++ b/input/fsh/operation-profiles/canonical-version-bindable-operation-profile.fsh
@@ -21,7 +21,7 @@ NOTE: This profile is here for backwards compatibility, see ArtifactVersionBinda
   * min = 0
   * max = "*"
   * use = #in
-  * type = #uri
+  * type = #canonical
 
 * parameter contains checkCanonicalVersion 0..* MS
 * parameter[checkCanonicalVersion]
@@ -29,7 +29,7 @@ NOTE: This profile is here for backwards compatibility, see ArtifactVersionBinda
   * min = 0
   * max = "*"
   * use = #in
-  * type = #uri
+  * type = #canonical
 
 * parameter contains forceCanonicalVersion 0..* MS
 * parameter[forceCanonicalVersion]
@@ -37,4 +37,4 @@ NOTE: This profile is here for backwards compatibility, see ArtifactVersionBinda
   * min = 0
   * max = "*"
   * use = #in
-  * type = #uri
+  * type = #canonical

--- a/input/fsh/operation-profiles/data-configurable-profile.fsh
+++ b/input/fsh/operation-profiles/data-configurable-profile.fsh
@@ -7,14 +7,10 @@ Operation where data endpoint configuration can be specified
 
 * `useServerData`: Whether to use data from the server performing the evaluation, exclusive with `dataEndpoint`.
 * `dataEndpoint`: An endpoint to use to access data referenced by retrieve operations in libraries, exclusive with `useServerData`.
-
 """
 
 * parameter
   * insert SliceOnName
-
-
-// TODO: Add invariant to allow one or the other of the following:
 
 * parameter contains useServerData 0..1 MS
 * parameter[useServerData]

--- a/input/fsh/operation-profiles/manifestable-operation-profile.fsh
+++ b/input/fsh/operation-profiles/manifestable-operation-profile.fsh
@@ -5,8 +5,7 @@ Title: "CRMI Operation Profile: Manifestable"
 Description: """
 Operation where default manifest to resolve canonicals can be specified
 
-* `manifest`: Library resource where related-artifacts are used to define the versions of canonical resources.
-* `manifestReference`: Canonical reference to existing manifest Library.
+* `manifest`: Canonical reference to a Library resource where related-artifacts are used to define the versions of canonical resources.
 """
 
 * parameter

--- a/input/fsh/operation-profiles/manifestable-operation-profile.fsh
+++ b/input/fsh/operation-profiles/manifestable-operation-profile.fsh
@@ -18,13 +18,5 @@ Operation where default manifest to resolve canonicals can be specified
   * min = 0
   * max = "1"
   * use = #in
-  * type = #Library
-
-* parameter contains manifestReference 0..1 MS
-* parameter[manifestReference]
-  * name = #manifestReference (exactly)
-  * min = 0
-  * max = "1"
-  * use = #in
   * type = #canonical
-  * searchType = #reference
+  * targetProfile = Canonical(http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-manifestlibrary)

--- a/input/fsh/operation-profiles/manifestable-operation-profile.fsh
+++ b/input/fsh/operation-profiles/manifestable-operation-profile.fsh
@@ -6,7 +6,7 @@ Description: """
 Operation where default manifest to resolve canonicals can be specified
 
 * `manifest`: Library resource where related-artifacts are used to define the versions of canonical resources.
-
+* `manifestReference`: Canonical reference to existing manifest Library.
 """
 
 * parameter
@@ -18,4 +18,13 @@ Operation where default manifest to resolve canonicals can be specified
   * min = 0
   * max = "1"
   * use = #in
-  * type = #uri
+  * type = #Library
+
+* parameter contains manifestReference 0..1 MS
+* parameter[manifestReference]
+  * name = #manifestReference (exactly)
+  * min = 0
+  * max = "1"
+  * use = #in
+  * type = #canonical
+  * searchType = #reference


### PR DESCRIPTION
This PR does the following:

* Update `manifest` parameter to be `type = #canonical` with a `targetProfile` to the CRMI ManifestLibrary profile
* For `$crmi.package` and `$crmi.data-requirements` operations:
  * Add Medication, MedicationKnowledge, and Substance resource types
  * Add ArtifactEndpointConfigurableOperation profile
* Update ArtifactEndpointConfigurableOperation to be inclusive of non-canonical artifacts
* For Operation Profiles:
  * Update the identifier parameters to be `type = #string` and `searchType = #token`
  * Wordsmith documentation to be inclusive of non-canonical artifacts
