### PR TITLE
[FHIR-50235](https://jira.hl7.org/browse/FHIR-50235) Move artifactComment to the publishable profiles

### DIFF
--- a/input/fsh/artifact-profiles/sharable-activitydefinition.fsh
+++ b/input/fsh/artifact-profiles/sharable-activitydefinition.fsh
@@ -7,7 +7,6 @@ Description: "Enforces the minimum information set for the activity definition m
 * extension contains
     $cqf-knowledgeCapability named knowledgeCapability 0..* MS and
     //$cqf-knowledgeRepresentationLevel named knowledgeRepresentationLevel 0..* MS and
-    ArtifactComment named artifactComment 0..* MS and 
     ArtifactVersionAlgorithm named versionAlgorithm 0..1 MS and
     ArtifactVersionPolicy named versionPolicy 0..1 MS
 * url 1..1 MS

--- a/input/profiles/StructureDefinition-crmi-publishableactivitydefinition.json
+++ b/input/profiles/StructureDefinition-crmi-publishableactivitydefinition.json
@@ -78,6 +78,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "ActivityDefinition.extension:artifactComment",
+      "path" : "ActivityDefinition.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "ActivityDefinition.identifier",
       "path" : "ActivityDefinition.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishablecapabilitystatement.json
+++ b/input/profiles/StructureDefinition-crmi-publishablecapabilitystatement.json
@@ -198,6 +198,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "CapabilityStatement.extension:artifactComment",
+      "path" : "CapabilityStatement.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "CapabilityStatement.date",
       "path" : "CapabilityStatement.date",
       "min" : 1,

--- a/input/profiles/StructureDefinition-crmi-publishablecodesystem.json
+++ b/input/profiles/StructureDefinition-crmi-publishablecodesystem.json
@@ -196,6 +196,18 @@
       }]
     },
     {
+      "id" : "CodeSystem.extension:artifactComment",
+      "path" : "CodeSystem.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "CodeSystem.identifier",
       "path" : "CodeSystem.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishableconceptmap.json
+++ b/input/profiles/StructureDefinition-crmi-publishableconceptmap.json
@@ -174,6 +174,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "ConceptMap.extension:artifactComment",
+      "path" : "ConceptMap.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "ConceptMap.identifier",
       "path" : "ConceptMap.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishablegraphdefinition.json
+++ b/input/profiles/StructureDefinition-crmi-publishablegraphdefinition.json
@@ -198,6 +198,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "GraphDefinition.extension:artifactComment",
+      "path" : "GraphDefinition.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "GraphDefinition.extension:relatedArtifact",
       "path" : "GraphDefinition.extension",
       "sliceName" : "relatedArtifact",

--- a/input/profiles/StructureDefinition-crmi-publishableimplementationguide.json
+++ b/input/profiles/StructureDefinition-crmi-publishableimplementationguide.json
@@ -210,6 +210,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "ImplementationGuide.extension:artifactComment",
+      "path" : "ImplementationGuide.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "ImplementationGuide.date",
       "path" : "ImplementationGuide.date",
       "min" : 1,

--- a/input/profiles/StructureDefinition-crmi-publishablelibrary.json
+++ b/input/profiles/StructureDefinition-crmi-publishablelibrary.json
@@ -78,6 +78,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "Library.extension:artifactComment",
+      "path" : "Library.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "Library.identifier",
       "path" : "Library.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishablemeasure.json
+++ b/input/profiles/StructureDefinition-crmi-publishablemeasure.json
@@ -66,6 +66,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "Measure.extension:artifactComment",
+      "path" : "Measure.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "Measure.identifier",
       "path" : "Measure.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishablenamingsystem.json
+++ b/input/profiles/StructureDefinition-crmi-publishablenamingsystem.json
@@ -215,6 +215,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "NamingSystem.extension:artifactComment",
+      "path" : "NamingSystem.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "NamingSystem.date",
       "path" : "NamingSystem.date",
       "min" : 1,

--- a/input/profiles/StructureDefinition-crmi-publishableoperationdefinition.json
+++ b/input/profiles/StructureDefinition-crmi-publishableoperationdefinition.json
@@ -210,6 +210,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "OperationDefinition.extension:artifactComment",
+      "path" : "OperationDefinition.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "OperationDefinition.date",
       "path" : "OperationDefinition.date",
       "min" : 1,

--- a/input/profiles/StructureDefinition-crmi-publishableplandefinition.json
+++ b/input/profiles/StructureDefinition-crmi-publishableplandefinition.json
@@ -66,6 +66,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "PlanDefinition.extension:artifactComment",
+      "path" : "PlanDefinition.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "PlanDefinition.identifier",
       "path" : "PlanDefinition.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishablequestionnaire.json
+++ b/input/profiles/StructureDefinition-crmi-publishablequestionnaire.json
@@ -150,6 +150,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "Questionnaire.extension:artifactComment",
+      "path" : "Questionnaire.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "Questionnaire.identifier",
       "path" : "Questionnaire.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishablesearchparameter.json
+++ b/input/profiles/StructureDefinition-crmi-publishablesearchparameter.json
@@ -210,6 +210,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "SearchParameter.extension:artifactComment",
+      "path" : "SearchParameter.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "SearchParameter.date",
       "path" : "SearchParameter.date",
       "min" : 1,

--- a/input/profiles/StructureDefinition-crmi-publishablestructuredefinition.json
+++ b/input/profiles/StructureDefinition-crmi-publishablestructuredefinition.json
@@ -186,6 +186,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "StructureDefinition.extension:artifactComment",
+      "path" : "StructureDefinition.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "StructureDefinition.identifier",
       "path" : "StructureDefinition.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-publishableterminologycapabilities.json
+++ b/input/profiles/StructureDefinition-crmi-publishableterminologycapabilities.json
@@ -198,6 +198,18 @@
       "mustSupport" : true
     },
     {
+      "id" : "TerminologyCapabilities.extension:artifactComment",
+      "path" : "TerminologyCapabilities.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "TerminologyCapabilities.date",
       "path" : "TerminologyCapabilities.date",
       "min" : 1,

--- a/input/profiles/StructureDefinition-crmi-publishablevalueset.json
+++ b/input/profiles/StructureDefinition-crmi-publishablevalueset.json
@@ -208,6 +208,18 @@
       }]
     },
     {
+      "id" : "ValueSet.extension:artifactComment",
+      "path" : "ValueSet.extension",
+      "sliceName" : "artifactComment",
+      "min" : 0,
+      "max" : "*",
+      "type" : [{
+        "code" : "Extension",
+        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
+      }],
+      "mustSupport" : false
+    },
+    {
       "id" : "ValueSet.identifier",
       "path" : "ValueSet.identifier",
       "mustSupport" : true

--- a/input/profiles/StructureDefinition-crmi-shareablecapabilitystatement.json
+++ b/input/profiles/StructureDefinition-crmi-shareablecapabilitystatement.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "CapabilityStatement.extension:artifactComment",
-      "path" : "CapabilityStatement.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "CapabilityStatement.extension:versionAlgorithm",
       "path" : "CapabilityStatement.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareablegraphdefinition.json
+++ b/input/profiles/StructureDefinition-crmi-shareablegraphdefinition.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "GraphDefinition.extension:artifactComment",
-      "path" : "GraphDefinition.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "GraphDefinition.extension:versionAlgorithm",
       "path" : "GraphDefinition.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareableimplementationguide.json
+++ b/input/profiles/StructureDefinition-crmi-shareableimplementationguide.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "ImplementationGuide.extension:artifactComment",
-      "path" : "ImplementationGuide.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "ImplementationGuide.extension:versionAlgorithm",
       "path" : "ImplementationGuide.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareablelibrary.json
+++ b/input/profiles/StructureDefinition-crmi-shareablelibrary.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "Library.extension:artifactComment",
-      "path" : "Library.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "Library.extension:versionAlgorithm",
       "path" : "Library.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareablemeasure.json
+++ b/input/profiles/StructureDefinition-crmi-shareablemeasure.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "Measure.extension:artifactComment",
-      "path" : "Measure.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "Measure.extension:versionAlgorithm",
       "path" : "Measure.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareableoperationdefinition.json
+++ b/input/profiles/StructureDefinition-crmi-shareableoperationdefinition.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "OperationDefinition.extension:artifactComment",
-      "path" : "OperationDefinition.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "OperationDefinition.extension:versionAlgorithm",
       "path" : "OperationDefinition.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareableplandefinition.json
+++ b/input/profiles/StructureDefinition-crmi-shareableplandefinition.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "PlanDefinition.extension:artifactComment",
-      "path" : "PlanDefinition.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "PlanDefinition.extension:versionAlgorithm",
       "path" : "PlanDefinition.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareablequestionnaire.json
+++ b/input/profiles/StructureDefinition-crmi-shareablequestionnaire.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "Questionnaire.extension:artifactComment",
-      "path" : "Questionnaire.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "Questionnaire.extension:versionAlgorithm",
       "path" : "Questionnaire.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareablesearchparameter.json
+++ b/input/profiles/StructureDefinition-crmi-shareablesearchparameter.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "SearchParameter.extension:artifactComment",
-      "path" : "SearchParameter.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "SearchParameter.extension:versionAlgorithm",
       "path" : "SearchParameter.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareablestructuredefinition.json
+++ b/input/profiles/StructureDefinition-crmi-shareablestructuredefinition.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "StructureDefinition.extension:artifactComment",
-      "path" : "StructureDefinition.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "StructureDefinition.extension:versionAlgorithm",
       "path" : "StructureDefinition.extension",
       "sliceName" : "versionAlgorithm",

--- a/input/profiles/StructureDefinition-crmi-shareableterminologycapabilities.json
+++ b/input/profiles/StructureDefinition-crmi-shareableterminologycapabilities.json
@@ -66,18 +66,6 @@
       "mustSupport" : true
     },
     {
-      "id" : "TerminologyCapabilities.extension:artifactComment",
-      "path" : "TerminologyCapabilities.extension",
-      "sliceName" : "artifactComment",
-      "min" : 0,
-      "max" : "*",
-      "type" : [{
-        "code" : "Extension",
-        "profile" : ["http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"]
-      }],
-      "mustSupport" : true
-    },
-    {
       "id" : "TerminologyCapabilities.extension:versionAlgorithm",
       "path" : "TerminologyCapabilities.extension",
       "sliceName" : "versionAlgorithm",


### PR DESCRIPTION
[FHIR-50235](https://jira.hl7.org/browse/FHIR-50235)
Move artifactComment to the publishable profiles

This PR moves the artifact comment extension from shareable to publishable profiles. The following shareable profiles did not include artifact comment, but these were added to the corresponding publishable artifacts so that all publishable profiles have the extension:
- concept map
- naming system
- value set
- code system