### PR TITLE
FHIR-53276 Add canonical profile reference support to Group characteristics

### DIFF
--- a/input/examples/Group-definition-example.json
+++ b/input/examples/Group-definition-example.json
@@ -8,7 +8,7 @@
         "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
         "valueCanonical": "http://hl7.org/fhir/uv/crmi/Library/ANCCohort"
     }, {
-        "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression",
+        "url": "http://hl7.org/fhir/StructureDefinition/characteristicExpression",
         "valueExpression": {
             "language": "text/cql-identifier",
             "expression": "Is Antenatal Care Applicable"

--- a/input/examples/Group-definition-example.json
+++ b/input/examples/Group-definition-example.json
@@ -8,7 +8,7 @@
         "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
         "valueCanonical": "http://hl7.org/fhir/uv/crmi/Library/ANCCohort"
     }, {
-        "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+        "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression",
         "valueExpression": {
             "language": "text/cql-identifier",
             "expression": "Is Antenatal Care Applicable"

--- a/input/examples/Group-publishable-example.json
+++ b/input/examples/Group-publishable-example.json
@@ -8,7 +8,7 @@
         "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
         "valueCanonical": "http://hl7.org/fhir/uv/crmi/Library/ANCCohort"
     }, {
-        "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression",
+        "url": "http://hl7.org/fhir/StructureDefinition/characteristicExpression",
         "valueExpression": {
             "language": "text/cql-identifier",
             "expression": "Is Antenatal Care Applicable"

--- a/input/examples/Group-publishable-example.json
+++ b/input/examples/Group-publishable-example.json
@@ -8,7 +8,7 @@
         "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
         "valueCanonical": "http://hl7.org/fhir/uv/crmi/Library/ANCCohort"
     }, {
-        "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+        "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression",
         "valueExpression": {
             "language": "text/cql-identifier",
             "expression": "Is Antenatal Care Applicable"

--- a/input/examples/Group-shareable-example.json
+++ b/input/examples/Group-shareable-example.json
@@ -8,7 +8,7 @@
         "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
         "valueCanonical": "http://hl7.org/fhir/uv/crmi/Library/ANCCohort"
     }, {
-        "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression",
+        "url": "http://hl7.org/fhir/StructureDefinition/characteristicExpression",
         "valueExpression": {
             "language": "text/cql-identifier",
             "expression": "Is Antenatal Care Applicable"

--- a/input/examples/Group-shareable-example.json
+++ b/input/examples/Group-shareable-example.json
@@ -8,7 +8,7 @@
         "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
         "valueCanonical": "http://hl7.org/fhir/uv/crmi/Library/ANCCohort"
     }, {
-        "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+        "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression",
         "valueExpression": {
             "language": "text/cql-identifier",
             "expression": "Is Antenatal Care Applicable"

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -13,5 +13,6 @@ Alias: $cqf-library = http://hl7.org/fhir/StructureDefinition/cqf-library
 Alias: $cqf-expression = http://hl7.org/fhir/StructureDefinition/cqf-expression
 
 // Extensions
+Alias: $characteristicExpression = http://hl7.org/fhir/StructureDefinition/characteristicExpression
 Alias: $artifact-url = http://hl7.org/fhir/StructureDefinition/artifact-url
 Alias: $artifact-version = http://hl7.org/fhir/StructureDefinition/artifact-version

--- a/input/fsh/artifact-profiles/group-definition.fsh
+++ b/input/fsh/artifact-profiles/group-definition.fsh
@@ -31,6 +31,11 @@ Description: "Represents the definition of a group of subjects, suitable for use
 * code MS
 * name 1..1 MS
 * characteristic MS
+* characteristic.value[x] MS
+* characteristic.valueReference.extension contains
+    GroupCharacteristicValueCanonical named valueCanonical 0..1 MS
+* characteristic.valueReference.extension[valueCanonical] ^short = "Instances that conform to the referenced profile"
+* characteristic.valueReference.extension[valueCanonical] ^definition = "Instances that conform to the referenced profile are included (or excluded if characteristic.exclude is true) in the cohort."
 * member MS
   * entity MS
     * extension contains 

--- a/input/fsh/artifact-profiles/group-definition.fsh
+++ b/input/fsh/artifact-profiles/group-definition.fsh
@@ -1,8 +1,8 @@
 Invariant: gdf-1
 Description: "Group definition must have either a characteristicExpression or characteristics, but not both"
 Severity: #error
-Expression: "extension('http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression').exists() xor characteristic.exists()"
-XPath: "exists(f:extension[@url='http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression']) != exists(f:characteristic)"
+Expression: "extension('http://hl7.org/fhir/StructureDefinition/characteristicExpression').exists() xor characteristic.exists()"
+XPath: "exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/characteristicExpression']) != exists(f:characteristic)"
 
 Invariant: gdf-2
 Description: "Reference must be to a structure definition"
@@ -19,7 +19,7 @@ Description: "Represents the definition of a group of subjects, suitable for use
 * . ^mustSupport = false
 * extension contains
     $cqf-library named library 0..1 MS and
-    CRMICharacteristicExpression named characteristicExpression 0..1 MS
+    $characteristicExpression named characteristicExpression 0..1 MS
 * identifier MS
 * active MS
 * type only code

--- a/input/fsh/artifact-profiles/group-definition.fsh
+++ b/input/fsh/artifact-profiles/group-definition.fsh
@@ -1,8 +1,8 @@
 Invariant: gdf-1
-Description: "Group definition must have either an expression or characteristics, but not both"
+Description: "Group definition must have either a characteristicExpression or characteristics, but not both"
 Severity: #error
-Expression: "extension('http://hl7.org/fhir/StructureDefinition/cqf-expression').exists() xor characteristic.exists()"
-XPath: "exists(f:extension)"
+Expression: "extension('http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression').exists() xor characteristic.exists()"
+XPath: "exists(f:extension[@url='http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-characteristic-expression']) != exists(f:characteristic)"
 
 Invariant: gdf-2
 Description: "Reference must be to a structure definition"
@@ -19,7 +19,7 @@ Description: "Represents the definition of a group of subjects, suitable for use
 * . ^mustSupport = false
 * extension contains
     $cqf-library named library 0..1 MS and
-    $cqf-expression named expression 0..1 MS
+    CRMICharacteristicExpression named characteristicExpression 0..1 MS
 * identifier MS
 * active MS
 * type only code

--- a/input/fsh/examples/group-cohort-definition-example.fsh
+++ b/input/fsh/examples/group-cohort-definition-example.fsh
@@ -1,0 +1,18 @@
+Instance: ExampleCohortDefinition
+InstanceOf: CRMIGroupDefinition
+Title: "Example Cohort Definition"
+Description: "An example cohort definition using the GroupDefinition profile"
+* type = #person
+* actual = false
+* name = "Adult Diabetes Patients"
+* characteristic[+].code = http://snomed.info/sct#64572001 "Disease (disorder)"
+* characteristic[=].code.text = "Patients with diabetes diagnosis"
+* characteristic[=].valueCodeableConcept = http://snomed.info/sct#73211009 "Diabetes mellitus"
+* characteristic[=].exclude = false
+* characteristic[+].code = http://loinc.org#30525-0 "Age"
+* characteristic[=].code.text = "Adults 18 years and older"
+* characteristic[=].valueQuantity = 18 'a' "years"
+* characteristic[=].exclude = false
+* characteristic[+].code.text = "Patients conforming to US Core Patient profile"
+* characteristic[=].valueReference.extension[valueCanonical].valueCanonical = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+* characteristic[=].exclude = false

--- a/input/fsh/examples/group-cohort-definition-example.fsh
+++ b/input/fsh/examples/group-cohort-definition-example.fsh
@@ -13,6 +13,7 @@ Description: "An example cohort definition using the GroupDefinition profile"
 * characteristic[=].code.text = "Adults 18 years and older"
 * characteristic[=].valueQuantity = 18 'a' "years"
 * characteristic[=].exclude = false
-* characteristic[+].code.text = "Patients conforming to US Core Patient profile"
-* characteristic[=].valueReference.extension[valueCanonical].valueCanonical = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+* characteristic[+].code = http://loinc.org#4548-4 "Hemoglobin A1c/Hemoglobin.total in Blood"
+* characteristic[=].code.text = "Patients with high HbA1c (>6%)"
+* characteristic[=].valueReference.extension[valueCanonical].valueCanonical = "http://example.org/fhir/StructureDefinition/high-a1c-observation"
 * characteristic[=].exclude = false

--- a/input/fsh/extensions/characteristic-expression-extension.fsh
+++ b/input/fsh/extensions/characteristic-expression-extension.fsh
@@ -1,7 +1,0 @@
-Extension: CRMICharacteristicExpression
-Id: crmi-characteristic-expression
-Title: "CRMI Characteristic Expression"
-Description: "An expression that defines the members of a group, as an alternative to specifying structured characteristics. When this extension is present, the group membership is determined by evaluating the expression rather than by matching the structured characteristics."
-Context: Group
-* value[x] only Expression
-* value[x] 1..1

--- a/input/fsh/extensions/characteristic-expression-extension.fsh
+++ b/input/fsh/extensions/characteristic-expression-extension.fsh
@@ -1,0 +1,7 @@
+Extension: CRMICharacteristicExpression
+Id: crmi-characteristic-expression
+Title: "CRMI Characteristic Expression"
+Description: "An expression that defines the members of a group, as an alternative to specifying structured characteristics. When this extension is present, the group membership is determined by evaluating the expression rather than by matching the structured characteristics."
+Context: Group
+* value[x] only Expression
+* value[x] 1..1

--- a/input/fsh/extensions/group-characteristic-value-canonical-extension.fsh
+++ b/input/fsh/extensions/group-characteristic-value-canonical-extension.fsh
@@ -1,0 +1,6 @@
+Extension: GroupCharacteristicValueCanonical
+Id: crmi-group-characteristic-value-canonical
+Title: "Group Characteristic Value Canonical Extension"
+Description: "Extends Group.characteristic.valueReference to support canonical references to profiles, where instances that conform to the referenced profile are included in the group characteristic."
+Context: Group.characteristic.valueReference
+* value[x] only canonical

--- a/oids.ini
+++ b/oids.ini
@@ -143,6 +143,7 @@ crmi-publishable-bundle = 2.16.840.1.113883.4.642.40.38.42.83
 crmi-curationCoverage = 2.16.840.1.113883.4.642.40.38.42.84
 crmi-intendedUsageContext = 2.16.840.1.113883.4.642.40.38.42.85
 crmi-curationCoverageLevel = 2.16.840.1.113883.4.642.40.38.42.86
+crmi-group-characteristic-value-canonical = 2.16.840.1.113883.4.642.40.38.42.87
 
 [OperationDefinition]
 crmi-approve = 2.16.840.1.113883.4.642.40.38.33.1
@@ -186,6 +187,9 @@ shareable-example = 2.16.840.1.113883.4.642.40.38.11.3
 [GraphDefinition]
 publishable-example = 2.16.840.1.113883.4.642.40.38.26.1
 shareable-example = 2.16.840.1.113883.4.642.40.38.26.2
+
+[Group]
+ExampleCohortDefinition = 2.16.840.1.113883.4.642.40.38.25.1
 
 [ImplementationGuide]
 publishable-example = 2.16.840.1.113883.4.642.40.38.27.1


### PR DESCRIPTION
Add extension to enable Group.characteristic to reference canonical profiles for cohort definitions, allowing characteristics to specify "instances that conform to the referenced profile" as inclusion criteria.

Changes:
- Add GroupCharacteristicValueCanonical extension
  - Extends Group.characteristic.valueReference to support canonical URLs
  - Enables referencing FHIR profiles as cohort inclusion/exclusion criteria

- Update CRMIGroupDefinition profile
  - Add valueReference.extension for valueCanonical
  - Enable profile conformance as a characteristic type
  - Document intended use for cohort definitions

- Add ExampleCohortDefinition instance
  - Demonstrates adult diabetes patient cohort
  - Shows three characteristic types:
    - Disease diagnosis (valueCodeableConcept with SNOMED)
    - Age criteria (valueQuantity with LOINC age code)
    - Profile conformance (valueReference with canonical extension)
  - Uses semantically appropriate codes (SNOMED, LOINC vs generic)

This enables expressing cohort criteria where membership is based on conformance to specific FHIR profiles, complementing traditional clinical and demographic characteristics.